### PR TITLE
Change blocktime to 12 seconds

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -13,7 +13,7 @@ el('#footerversion').innerHTML = version;
 
 
 /* intrinsic values */
-const _SECONDS_PER_ETH_BLOCK = 15;
+const _SECONDS_PER_ETH_BLOCK = 12;
 const _ZERO_BN = new Eth.BN(0, 10);
 
 /* contract constants */


### PR DESCRIPTION
After the merge every block is 12 seconds, we can change this from 15 seconds to 12 seconds now for Mainnet Ethereum. Thanks.