### PR TITLE
Update for Error and blocktime fix

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -13,7 +13,7 @@ el('#footerversion').innerHTML = version;
 
 
 /* intrinsic values */
-const _SECONDS_PER_ETH_BLOCK = 15;
+const _SECONDS_PER_ETH_BLOCK = 12;
 const _ZERO_BN = new Eth.BN(0, 10);
 
 /* contract constants */
@@ -552,6 +552,9 @@ function updateAllMinerInfo(eth, stats, hours_into_past){
   }
 
   var start_log_search_at = Math.max(last_difficulty_start_block, last_imported_mint_block + 1);
+  if(last_reward_eth_block - start_log_search_at < 1){
+    start_log_search_at = last_reward_eth_block - 1
+  }
 
   log("searching last", last_reward_eth_block - start_log_search_at, "blocks");
 


### PR DESCRIPTION
Error reproduction.  
1) Load https://0x1d00ffff.github.io/0xBTC-Stats/?page=stats 2) Let the Mints load at the bottom of page, should say "searching last 30000 blocks" In browser console 3) Reload page, suddenly Mints don't load.  Why?  Error.

The Error is because it tries searching -1 blocks (You can't search into the future). The Browser Console reads, "0.47s  searching last -1 blocks"

Even if you reload, it doesn't load the Mints, The only way to load Mints again is to clear your cookies (currently).

My Fix stops this error from happening everytime so people can see the Blocks minted everytime they load the page. Reload page

Also fixed ETH Block time to 12 seconds now that that is static post Merge (9/01/22).

You can see the code working, unlimited refreshes @ https://abastoken.org/0xBTC-Stats/?page=stats&